### PR TITLE
Feat: 'About' Page integration

### DIFF
--- a/Implementation/inner-works-theme/page-about.php
+++ b/Implementation/inner-works-theme/page-about.php
@@ -1,0 +1,39 @@
+<?php
+/* Template Name: About Page */
+get_header();
+?>
+
+<main>
+    <section class="iwc-section iwc-section-light-blue">
+        <div class="container pt-4 pb-4">
+            <div class="row">
+                <nav aria-label="breadcrumb">
+                    <ol class="breadcrumb">
+                        <li class="breadcrumb-item"><a href="<?php echo home_url(); ?>">Home</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">About</li>
+                    </ol>
+                </nav>
+                <div class="col-md-12 text-center">
+                    <h1 class="mb-5 iwc-blue"><?php the_title(); ?></h1>
+                </div>
+            </div>
+            <div class="row text-center g-4">
+                <div class="col-lg-4">
+                    <img src="<?php the_field('about_image'); ?>" alt="Lita Oakes" class="img-fluid mb-3">
+                    <h5 class="text-center"><span class="fw-bold">Accredited Counsellor</span><br>Lita Oakes</h5>
+                </div>
+                <div class="col-lg-8">
+                    <?php the_content() ?>
+                </div>
+            </div>
+            <div class="row mt-2 mb-2">
+                <div class="col-md-12 mt-5 mb-5 d-flex flex-column flex-md-row align-items-center justify-content-center gap-3 gap-lg-4">
+                    <a class="iwc-btn bg-white" data-bs-toggle="modal" data-bs-target="#getFWT">Get Free Wellbeing Tips</a>
+                    <a href="http://bensv.youcanbook.me" class="iwc-btn" target="_blank">Book Appointment Now</a>
+                </div>
+            </div>
+        </div>
+    </section>
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
# Add Customizable About Page Template

## Description:
This commit introduces a custom template for the “About” page in our WordPress theme. The template is designed to provide a structured and visually appealing layout for presenting information about our accredited counsellor, Lita Oakes, and includes sections for breadcrumbs, a title, an image, content, and call-to-action buttons

## Definitions:

- Template Name: About Page
- get_header() call the header page to be implemented.
- get_footer() call the footer page to be implemented.

## Custom Fields:
- Title of the page: the_title()
- Profile Image of Lita: the_field('about_image')
- Content: the_content()
*These fields allow the client to dynamically display content and make it easy to update.*

Finally, consider the buttons to access the Booking System directly and another button to access Get Free Wellbeing Tips.
Solve #57 


